### PR TITLE
Fix "field pruning" to "field punning" typo

### DIFF
--- a/CheatSheet.org
+++ b/CheatSheet.org
@@ -257,7 +257,7 @@ let input = read_line ();;
   let {x = px; y = py} = p;;
   let go {x = qx; y = qy} = qx +. qy;;
 
-  (* More tersely, using “field pruning”: Variables must coincide with field names. *)
+  (* More tersely, using “field punning”: Variables must coincide with field names. *)
   let erroenous ({xx; y} : point2d )= x +. y;;
   let works {x; y} = 0.0;;
 


### PR DESCRIPTION
Inferring fields from their name in records is called "punning", not "pruning": https://v1.realworldocaml.org/v1/en/html/records.html